### PR TITLE
Workspace based config path

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -59,7 +59,8 @@ class LuaFormatProvider implements vscode.DocumentFormattingEditProvider {
 
             if (configPath) {
                 if (!path.isAbsolute(configPath)) {
-                    configPath = this.context.asAbsolutePath(configPath);
+                    configPath = path.resolve(vscode.workspace.rootPath, configPath);
+                    //configPath = this.context.asAbsolutePath(configPath);
                 }
                 args.push("-c");
                 args.push(configPath);


### PR DESCRIPTION
Fixed to search files by workspace root rather than extension installation root when using configPath as relative path